### PR TITLE
Fix history handling in chatbot

### DIFF
--- a/wikiart_chatbot/chatbot.py
+++ b/wikiart_chatbot/chatbot.py
@@ -196,16 +196,18 @@ Style: {row['style']}
 Genre: {row['genre']}
 Description: {row['description']}"""
 
-    def process_message(self, message: str, history: List[Dict]) -> Tuple[str, List[Dict]]:
+    def process_message(self, message: str, history: Optional[List[Dict]]) -> Tuple[str, List[Dict]]:
         """Process a user message and return the response with updated history.
         
         Args:
             message: The user's message.
-            history: The current conversation history.
+            history: The current conversation history. If ``None``, a new
+                history list will be created.
             
         Returns:
             Tuple containing an empty string and the updated history.
         """
+        history = history or []
         try:
             matches = self.search_wikiart(message)
             if matches.empty:

--- a/wikiart_chatbot/ui.py
+++ b/wikiart_chatbot/ui.py
@@ -34,7 +34,7 @@ def create_ui(config: Optional[Config] = None) -> gr.Blocks:
             )
             submit = gr.Button("Send", variant="primary")
         
-        def respond(message: str, chat_history: List[Dict]) -> Tuple[str, List[Dict]]:
+        def respond(message: str, chat_history: Optional[List[Dict]]) -> Tuple[str, List[Dict]]:
             return chatbot.process_message(message, chat_history)
         
         submit.click(respond, [msg, chatbot_interface], [msg, chatbot_interface])


### PR DESCRIPTION
## Summary
- allow optional chat history in process_message
- update UI callback to accept optional history

## Testing
- `python -m py_compile main.py wikiart_chatbot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683f68cded888332a850fd2936981cbe