### PR TITLE
Improve index instructions and config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ python main.py
 
 3. Open your browser and navigate to the URL shown in the terminal (usually http://localhost:7860)
 
+## Creating the FAISS index
+
+The first time you run the chatbot it will automatically generate `wikiart_index.faiss` from `wikiart_metadata.csv`. If you prefer to create the index separately, run:
+
+```bash
+python build_index.py
+```
+
 ## Project Structure
 
 ```

--- a/build_index.py
+++ b/build_index.py
@@ -1,0 +1,37 @@
+"""Utility script to create the FAISS index for WikiArt metadata."""
+
+from pathlib import Path
+
+import faiss
+import numpy as np
+import pandas as pd
+from sentence_transformers import SentenceTransformer
+
+from wikiart_chatbot.config import Config
+
+
+def build_index():
+    """Generate and save the FAISS index from the metadata."""
+    config = Config()
+    metadata_path = Path("wikiart_metadata.csv")
+    index_path = Path(config.index_path)
+
+    if not metadata_path.exists():
+        raise FileNotFoundError(f"Metadata file not found at {metadata_path}")
+
+    df = pd.read_csv(metadata_path, quoting=1)
+    texts = df.apply(
+        lambda row: f"{row['title']} by {row['artist']} - {row['style']} ({row['year']}): {row['description']}",
+        axis=1,
+    )
+
+    embedding_model = SentenceTransformer(config.embedding_model)
+    embeddings = embedding_model.encode(texts.tolist(), show_progress_bar=True)
+    index = faiss.IndexFlatL2(embeddings.shape[1])
+    index.add(np.array(embeddings))
+    faiss.write_index(index, str(index_path))
+    print(f"Index saved to {index_path}")
+
+
+if __name__ == "__main__":
+    build_index()

--- a/wikiart_chatbot/config.py
+++ b/wikiart_chatbot/config.py
@@ -9,6 +9,7 @@ DEFAULT_OLLAMA_URL = "http://localhost:11434/api/generate"
 DEFAULT_TOP_K = 3
 DEFAULT_MAX_HISTORY = 10
 DEFAULT_TIMEOUT = 30
+DEFAULT_INDEX_PATH = "wikiart_index.faiss"
 
 @dataclass
 class Config:
@@ -18,4 +19,5 @@ class Config:
     embedding_model: str = DEFAULT_EMBEDDING_MODEL
     ollama_url: str = DEFAULT_OLLAMA_URL
     max_history: int = DEFAULT_MAX_HISTORY
-    timeout: int = DEFAULT_TIMEOUT 
+    timeout: int = DEFAULT_TIMEOUT
+    index_path: str = DEFAULT_INDEX_PATH


### PR DESCRIPTION
## Summary
- add instructions for building the FAISS index
- expose index path in the configuration
- include helper script `build_index.py` to generate the index

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f6eb563b88332872fb807963b850f