### PR TITLE
Add packaging and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ source wikiart-env/bin/activate
 pip install -r requirements.txt
 ```
 
+4. Install the package locally so it can be imported anywhere:
+
+```bash
+pip install -e .
+```
+
 ## Usage
 
 1. Make sure Ollama is running:
@@ -78,6 +84,15 @@ You can customize the chatbot by modifying the default settings in `wikiart_chat
 - Search parameters
 - History length
 - Timeout settings
+
+## Running Tests
+
+To run the unit tests, install the development dependencies and execute `pytest`:
+
+```bash
+pip install -e .[dev]
+pytest
+```
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wikiart-chatbot"
+version = "1.0.0"
+description = "AI-powered chatbot that provides information about artworks using semantic search and LLM technology"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Your Name"}]
+dependencies = [
+    "pandas>=2.0.0",
+    "numpy>=1.24.0",
+    "faiss-cpu>=1.7.4",
+    "requests>=2.31.0",
+    "gradio>=4.0.0",
+    "sentence-transformers>=2.2.2"
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[tool.setuptools]
+packages = ["wikiart_chatbot"]

--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from wikiart_chatbot.chatbot import WikiArtChatbot
+
+
+def test_format_artwork_info():
+    chatbot = object.__new__(WikiArtChatbot)
+    row = pd.Series({
+        "title": "Mona Lisa",
+        "artist": "Leonardo da Vinci",
+        "year": 1503,
+        "style": "Renaissance",
+        "genre": "Portrait",
+        "description": "A painting of Mona Lisa"
+    })
+    expected = (
+        "Title: Mona Lisa\n"
+        "Artist: Leonardo da Vinci\n"
+        "Year: 1503\n"
+        "Style: Renaissance\n"
+        "Genre: Portrait\n"
+        "Description: A painting of Mona Lisa"
+    )
+    assert chatbot.format_artwork_info(row) == expected


### PR DESCRIPTION
## Summary
- introduce Python packaging via pyproject.toml
- add tests directory with a unit test for `format_artwork_info`
- document installation and testing steps in README

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6eb663588332a883332700ec0978