### PR TITLE
Improve HTTP error handling for Ollama requests

### DIFF
--- a/tests/test_chatbot.py
+++ b/tests/test_chatbot.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+import requests
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from wikiart_chatbot.chatbot import WikiArtChatbot
+from wikiart_chatbot.config import Config
+from wikiart_chatbot.exceptions import OllamaError
+
+
+def create_bot():
+    bot = WikiArtChatbot.__new__(WikiArtChatbot)
+    bot.config = Config()
+    return bot
+
+
+def test_make_ollama_request_raises_for_status():
+    bot = create_bot()
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError()
+    with patch('requests.post', return_value=mock_response) as mock_post:
+        with pytest.raises(requests.exceptions.HTTPError):
+            bot._make_ollama_request('prompt')
+        mock_post.assert_called_once()
+        mock_response.raise_for_status.assert_called_once()
+
+
+def test_process_ollama_response_success():
+    bot = create_bot()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {'response': 'hi'}
+    assert bot._process_ollama_response(mock_response) == 'hi'
+
+
+def test_process_ollama_response_missing_key():
+    bot = create_bot()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {}
+    with pytest.raises(OllamaError):
+        bot._process_ollama_response(mock_response)

--- a/wikiart_chatbot/chatbot.py
+++ b/wikiart_chatbot/chatbot.py
@@ -146,7 +146,7 @@ class WikiArtChatbot:
         Raises:
             requests.exceptions.RequestException: If the request fails.
         """
-        return requests.post(
+        response = requests.post(
             self.config.ollama_url,
             json={
                 "model": self.config.model,
@@ -155,6 +155,8 @@ class WikiArtChatbot:
             },
             timeout=self.config.timeout
         )
+        response.raise_for_status()
+        return response
 
     def _process_ollama_response(self, response: requests.Response) -> str:
         """Process the response from the Ollama API.
@@ -168,11 +170,6 @@ class WikiArtChatbot:
         Raises:
             OllamaError: If the response cannot be processed.
         """
-        if response.status_code != 200:
-            logger.error(f"Ollama API error: Status code {response.status_code}")
-            logger.error(f"Response: {response.text}")
-            raise OllamaError(f"Received error from AI model (Status code: {response.status_code})")
-        
         response_data = response.json()
         if "response" not in response_data:
             logger.error(f"Unexpected response format: {response_data}")


### PR DESCRIPTION
## Summary
- call `raise_for_status()` after POSTing to Ollama
- adjust response processing logic
- add unit tests covering Ollama error cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6eb31f248332b9ee18da29924ea8